### PR TITLE
Update quickstart.mdx

### DIFF
--- a/documentation/quickstart.mdx
+++ b/documentation/quickstart.mdx
@@ -106,7 +106,7 @@ yarn @trigger.dev/cli@latest dev
 
 <AccordionGroup>
 <Accordion title="Experiencing an error? This could be due to middleware.">
-Instructions of how to resolve any issues due to middleware [here](https://trigger.dev/documentation/guides/platforms/nextjs#middleware)
+Instructions of how to resolve any issues due to middleware [here](https://trigger.dev/docs/documentation/guides/platforms/nextjs#middleware)
 </Accordion>
 
 <Accordion title="Advanced: Run your Next.js server together with the CLI">


### PR DESCRIPTION
The path for the docs URLs has changed. The old link was broken.

Old path: https://trigger.dev/documentation/
New path: https://trigger.dev/docs/documentation/

I am not sure if there is other places where this should be updated for broken links