### PR TITLE
Update crontrigger.mdx

### DIFF
--- a/sdk/crontrigger.mdx
+++ b/sdk/crontrigger.mdx
@@ -13,7 +13,7 @@ CRON expressions are strings that define when something should happen.
 
 Some examples:
 
-- `"0 0 * * *"`: will run the Job every hour at the top of the hour.
+- `"0 0 * * *"`: will run the Job every day at 12:00am UTC.
 - `"30 14 * * 1"`: will run the Job every Monday at 2:30pm UTC.
 
 A useful tool when writing CRON expressions is [crontab guru](https://crontab.guru).


### PR DESCRIPTION
The cronexpression ```0 0 * * *``` runs every day at midnight not at the top of the hour every hour.
[https://crontab.guru/#0_0_*_*_*](https://crontab.guru/#0_0_*_*_*)

```0 * * * *``` runs every hour at the top of the hour.
[https://crontab.guru/#0_*_*_*_*](https://crontab.guru/#0_*_*_*_*)

I am not sure which version you wanted in the docs feel free to change it.