### PR TITLE
Update introduction.mdx to link to https://cloud.trigger.dev

### DIFF
--- a/documentation/introduction.mdx
+++ b/documentation/introduction.mdx
@@ -5,7 +5,7 @@ description: "Welcome to the Trigger.dev documentation!"
 
 Trigger.dev is an open source framework for creating long-running Jobs directly in your Next.js app with API Integrations, webhooks, scheduling and delays. You can reliably run Jobs that wouldn't normally work in serverless environments (like Vercel) because of timeouts.
 
-You can use [Trigger.dev Cloud](https://trigger.dev) or [Self-host Trigger.dev](/documentation/guides/self-hosting) on your own infrastructure.
+You can use [Trigger.dev Cloud](https://cloud.trigger.dev) or [Self-host Trigger.dev](/documentation/guides/self-hosting) on your own infrastructure.
 
 <CardGroup>
   <Card title="Quick start" icon="person-running-fast" href="quickstart">


### PR DESCRIPTION
The link for the introduction documentation does not link to the https://cloud.trigger.dev site but the main site currently.
